### PR TITLE
Fix out of bounds error when scrolling

### DIFF
--- a/src/main/java/io/github/darkkronicle/advancedchat/gui/ChatLogScreen.java
+++ b/src/main/java/io/github/darkkronicle/advancedchat/gui/ChatLogScreen.java
@@ -170,17 +170,19 @@ public class ChatLogScreen extends GuiBase {
             }
             int startLine = scrolledLines + 1;
             int endLine = filteredLines.size();
-            for (int i = filteredLines.size() - 1; i + scrolledLines >= 0; i--) {
-                ChatLogMessage line = filteredLines.get(i + scrolledLines);
-                lines++;
-                int relativeHeight = (lines * lineHeight);
-                int height = (windowHeight - bottomScreenOffset) - relativeHeight;
+            for (int i = filteredLines.size() - 1; i >= 0; i--) {
+                if(i - scrolledLines >= 0) {
+                    ChatLogMessage line = filteredLines.get(i - scrolledLines);
+                    lines++;
+                    int relativeHeight = (lines * lineHeight);
+                    int height = (windowHeight - bottomScreenOffset) - relativeHeight;
 
-                if (relativeHeight > maxheight) {
-                    endLine = i + scrolledLines;
-                    break;
+                    if (relativeHeight > maxheight) {
+                        endLine = i + scrolledLines;
+                        break;
+                    }
+                    drawTextWithShadow(matrices, client.textRenderer, line.getDisplayText(), 20, height + 1, textColor.color());
                 }
-                drawTextWithShadow(matrices, client.textRenderer, line.getDisplayText(), 20, height + 1, textColor.color());
             }
             DrawableHelper.drawCenteredText(matrices, client.textRenderer, startLine + "-" + endLine + "/" + filteredLines.size(), client.getWindow().getScaledWidth() / 2, 10, ColorUtil.WHITE.color());
 


### PR DESCRIPTION
This PR fixes the crash which occurs when you attempt to scroll when you are already at the top of the chat log.

The crash looked like this:
```java.lang.IndexOutOfBoundsException: Index 6 out of bounds for length 4
    at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
    at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
    at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
    at java.base/java.util.Objects.checkIndex(Objects.java:359)
    at java.base/java.util.ArrayList.get(ArrayList.java:427)
    at io.github.darkkronicle.advancedchat.gui.ChatLogScreen.method_25394(ChatLogScreen.java:174)
    at net.minecraft.class_757.method_3192(class_757.java:874)
    at net.minecraft.class_310.method_1523(class_310.java:1112)
    at net.minecraft.class_310.method_1514(class_310.java:728)
    at net.minecraft.client.main.Main.main(Main.java:217)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:567)
    at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:234)
    at net.fabricmc.loader.launch.knot.Knot.launch(Knot.java:153)
    at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28)
```

Before the 1.17 beta commit, the chat log was reversed. This was fixed but introduced this crash. This PR keeps the correct order for chat messages, but fixes that crash.